### PR TITLE
make Integer backed by int64 to support 32-bit platforms

### DIFF
--- a/lib/bencode.ml
+++ b/lib/bencode.ml
@@ -45,7 +45,7 @@ let spaces level = empty_string (level * 2)
 
 let rec pretty_print =
   let rec loop level = function
-    | Integer x -> string_of_int x
+    | Integer x -> Int64.to_string x
     | String x -> Printf.sprintf "<string:%d>" (String.length x)
     | List l ->
       format_list l ~f:(fun buf e ->
@@ -64,7 +64,7 @@ let rec pretty_print =
 
 module Str_conv = struct
   open Printf
-  let of_int i = sprintf "i%de" i
+  let of_int i = sprintf "i%Lde" i
   let of_string s = sprintf "%d:%s" (String.length s) s
   let of_list ?(c='l') s ~f =
     let buf = Buffer.create 10 in

--- a/lib/bencode.mli
+++ b/lib/bencode.mli
@@ -1,7 +1,7 @@
 (** Read and write bencode files in OCaml *)
 
 type t =
-  | Integer of int
+  | Integer of int64
   | String of string
   | List of t list
   | Dict of (string * t) list
@@ -45,7 +45,7 @@ val encode_seq : [< dst] -> t sequence -> unit
 (** {2 Helpers} *)
 
 val as_string : t -> string option
-val as_int : t -> int option
+val as_int : t -> int64 option
 val as_list : t -> t list option
 val as_dict : t -> (string * t) list option
 val dict_get : t -> string -> t option

--- a/lib/bencode_lex.mll
+++ b/lib/bencode_lex.mll
@@ -22,7 +22,7 @@ and bencode = parse
   }
   | 'i' '-'? ['0'-'9']+ 'e' {
       let str = lexeme lexbuf in
-      INT (int_of_string (
+      INT (Int64.of_string (
           String.sub str 1 (String.length str - 2)
         ))
     }

--- a/lib/bencode_parse.mly
+++ b/lib/bencode_parse.mly
@@ -1,7 +1,7 @@
 %{
   open Bencode_types
 %}
-%token <int> INT
+%token <int64> INT
 %token <string> STRING
 %token LIST_START
 %token DICT_START

--- a/lib/bencode_streaming.ml
+++ b/lib/bencode_streaming.ml
@@ -44,8 +44,7 @@ module Encode = struct
     and write_str s =
       write_int (String.length s);
       write_char ':';
-      String.blit s 0 buf !pos (String.length s);
-      pos := !pos + String.length s
+      write_raw_str s
     and write_char c =
       Bytes.set buf !pos c;
       incr pos

--- a/lib/bencode_streaming.ml
+++ b/lib/bencode_streaming.ml
@@ -7,19 +7,13 @@ type 'a sequence = ('a -> unit) -> unit
 (** {2 Serialization (encoding)} *)
 
 module Encode = struct
-  let _len_min_int = String.length (string_of_int min_int)
-
   (* length of an encoded int, in bytes *)
-  let _len_int i =
-    match i with
-    | 0 -> 1
-    | _ when i=min_int -> _len_min_int
-    | _ when i < 0 -> 2 + int_of_float (log10 (float_of_int ~-i))
-    | _ -> 1 + int_of_float (log10 (float_of_int i))
+  let _len_int i = String.length (Int64.to_string i)
 
   (* length of an encoded string, in bytes *)
   let _len_str s =
-    _len_int (String.length s) + 1 + String.length s
+    let payload_len = String.length s in
+    _len_int (Int64.of_int payload_len) + 1 + payload_len
 
   let rec size t = match t with
     | Integer i -> 2 + _len_int i
@@ -30,7 +24,7 @@ module Encode = struct
   let write_in_string t buf o =
     let pos = ref o in
     let rec append t = match t with
-    | Integer i -> write_char 'i'; write_int i; write_char 'e'
+    | Integer i -> write_char 'i'; write_int64 i; write_char 'e'
     | String s -> write_str s
     | List l ->
       write_char 'l';
@@ -40,10 +34,13 @@ module Encode = struct
       write_char 'd';
       List.iter (fun (key, t') -> write_str key; append t') m;
       write_char 'e'
-    and write_int i =
-      let s = string_of_int i in
+    and write_raw_str s =
       Bytes.blit_string s 0 buf !pos (String.length s);
       pos := !pos + String.length s
+    and write_int i =
+      write_raw_str (string_of_int i)
+    and write_int64 i =
+      write_raw_str (Int64.to_string i)
     and write_str s =
       write_int (String.length s);
       write_char ':';
@@ -99,7 +96,7 @@ module Encode = struct
 end
 
 let rec pretty fmt t = match t with
-  | Integer i -> Format.fprintf fmt "%d" i
+  | Integer i -> Format.fprintf fmt "%Ld" i
   | String s -> Format.fprintf fmt "@[<h>\"%s\"@]" s
   | List l ->
     Format.fprintf fmt "@[<hov 2>[@,";

--- a/lib/bencode_token.mli
+++ b/lib/bencode_token.mli
@@ -2,7 +2,7 @@
 
 type t =
   [
-  | `I of int
+  | `I of int64
   | `S of string
   | `BeginDict
   | `BeginList

--- a/lib/bencode_types.ml
+++ b/lib/bencode_types.ml
@@ -1,5 +1,5 @@
 type t =
-  | Integer of int
+  | Integer of int64
   | String of string
   | List of t list
   | Dict of (string * t) list

--- a/lib_test/test_ounit.ml
+++ b/lib_test/test_ounit.ml
@@ -8,15 +8,16 @@ let test1 _ =
   let s = "li42ei0ei-200ee" in
   match BS.Decode.parse_string s with
   | Some b ->
-    OUnit.assert_equal (B.List [B.Integer 42; B.Integer 0; B.Integer ~-200]) b
+    OUnit.assert_equal (B.List [B.Integer 42_L; B.Integer 0_L;
+                                B.Integer (Int64.neg 200_L)]) b
   | None ->
     OUnit.assert_failure "should parse"
 
 let test2 _ =
   let b =
     B.dict_of_list [
-      "foo", B.Integer 42;
-      "bar", B.List [B.Integer 0; B.String "caramba si"];
+      "foo", B.Integer 42_L;
+      "bar", B.List [B.Integer 0_L; B.String "caramba si"];
       "", B.String "";
     ]
   in
@@ -27,9 +28,9 @@ let test2 _ =
 
 let test3 _ =
   let b = B.dict_of_list [
-    "a", B.Integer 1;
+    "a", B.Integer 1_L;
     "b", B.String "bbbb";
-    "l", B.List [B.Integer 0; B.Integer 0; B.String "zero\n\t \x00"];
+    "l", B.List [B.Integer 0_L; B.Integer 0_L; B.String "zero\n\t \x00"];
     "d", B.dict_of_list ["foo", B.String "bar"];
   ] in
   let s = BS.Encode.to_string b in
@@ -39,11 +40,11 @@ let test3 _ =
 
 (* issue #4 *)
 let regression_4 _ =
-  let s = BS.Encode.to_string (B.Integer min_int) in
+  let s = BS.Encode.to_string (B.Integer (Int64.of_int min_int)) in
   OUnit.assert_equal ~printer:(Printf.sprintf "%S")
     "i-4611686018427387904e" s;
   OUnit.assert_equal ~printer:BS.Encode.to_string ~cmp:B.eq
-    (B.Integer min_int) (BS.Decode.parse_string_exn s);
+    (B.Integer (Int64.of_int min_int)) (BS.Decode.parse_string_exn s);
   ()
 
 let suite =

--- a/lib_test/test_qcheck.ml
+++ b/lib_test/test_qcheck.ml
@@ -11,8 +11,8 @@ let arb_bencode =
     let open QCheck.Gen in
     let base =
       frequency
-        [ 4, (small_int >|= fun i -> B.Integer i);
-          1, (oneofl [min_int; max_int] >|= fun i -> B.Integer i);
+        [ 4, (small_int >|= fun i -> B.Integer (Int64.of_int i));
+          1, (oneofl [Int64.min_int; Int64.max_int] >|= fun i -> B.Integer i);
           5, (string >|= fun s -> B.String s);
         ]
     in
@@ -30,7 +30,7 @@ let arb_bencode =
     let open Q.Iter in
     match b with
       | B.List l -> Q.Shrink.list ~shrink l >|= fun l->B.List l
-      | B.Integer i -> Q.Shrink.int i >|= fun i -> B.Integer i
+      | B.Integer i -> Q.Shrink.nil i >|= fun i -> B.Integer i (* TODO I couldn't figure out how to implement a shrinking function *)
       | _ -> Q.Iter.empty
   in
   Q.make
@@ -54,7 +54,7 @@ let check_decode_encode_token =
   let (arb_token_l : Bencode_token.t list Q.arbitrary) =
     let gen = Q.Gen.(
         small_list (oneof
-            [ map (fun i -> `I i) small_int
+            [ map (fun i -> `I (Int64.of_int i)) small_int
             ; map (fun s -> `S s) string
             ; oneofl [ `BeginDict; `BeginList; `End ] ]
         )

--- a/lib_test/test_qcheck.ml
+++ b/lib_test/test_qcheck.ml
@@ -30,9 +30,10 @@ let arb_bencode =
   let rec shrink_int64 : int64 Q.Shrink.t =
     fun x ->
       let open Q.Iter in
-      ( ( return @@ Int64.div x 2_L )
-        <+> (return @@ Int64.(sub x one))
-      ) >>= shrink_int64
+      if x = 0_L then
+        empty
+      else (     return Int64.(div x 2_L)
+             <+> return Int64.(sub x one) )
   in
   let rec shrink b =
     let open Q.Iter in


### PR DESCRIPTION
I couldn't figure out how to implement a shrinking function for the QCheck test - if someone can point me in the right direction I'll try to fiddle a bit more with that:
https://github.com/rgrinberg/bencode/compare/master...cfcs:int64?expand=1#diff-b1435fa88f2ff1f1e9a1b206635197a9R33

resolves https://github.com/rgrinberg/bencode/issues/7

ping @rgrinberg 

EDIT: travis-ci test: https://travis-ci.org/cfcs/bencode/builds/381134695
I ran the testsuite locally and that seemed fine, but then again I also changed some things in the test suite, so...