### PR TITLE
pp: implement Format.formatter-style pretty-printer

### DIFF
--- a/lib/bencode.ml
+++ b/lib/bencode.ml
@@ -72,7 +72,7 @@ let pp (fmt:Format.formatter) (benc:t) =
                ) ("^--" :: List.rev nestlvl)
   in
   let rec pp_val (nestlvl:string list) fmt = function
-    | Integer x -> Format.pp_print_string fmt @@ Int64.to_string x
+    | Integer x -> Format.fprintf fmt "%Ld" x
     | String x when String.length x <= 40 ->
       Format.fprintf fmt "<string:%d:%S>" (String.length x) x
     | String x ->

--- a/lib/bencode.ml
+++ b/lib/bencode.ml
@@ -86,13 +86,14 @@ let pp (fmt:Format.formatter) (benc:t) =
       Format.fprintf fmt "@[<v>[  @[<v>%a@]@ ] ;@]"
         Format.(pp_print_list ~pp_sep:Format.pp_print_cut @@ pp_val nestlvl) lst
     | Dict lst ->
-      let last_key = ref "" in
-      let annotate_order key =
-        let annot = match key with (* alert the user if keys are invalid*)
-          | _ when key = !last_key -> " (* error: duplicate key *)"
-          | _ when key > !last_key -> ""
+      let last_key = ref None in
+      let annotate_order key = (* alert the user if keys are invalid: *)
+        let annot = match key, !last_key with
+          | _, None -> ""
+          | _, Some prev when key = prev -> " (* error: duplicate key *)"
+          | _, Some prev when key > prev -> ""
           | _ -> " (* error: out of order, BEP-003 needs ascending key order *)"
-        in last_key := key ; annot
+        in last_key := Some key ; annot
       in
       Format.fprintf fmt "@[<v>{  @[<v>%a@]@ } ;@]"
         Format.(pp_print_list ~pp_sep:Format.pp_print_cut (fun fmt (key,x) ->

--- a/lib/bencode.ml
+++ b/lib/bencode.ml
@@ -62,6 +62,49 @@ let rec pretty_print =
           Buffer.add_string buf ";\n")
   in loop 1
 
+let pp (fmt:Format.formatter) (benc:t) =
+  let pp_nest fmt nestlvl = (* prints a comment explaining tree context *)
+    if nestlvl = [] then ()
+    else Format.fprintf fmt " (* %a *)"
+        Format.(pp_print_list
+                  ~pp_sep:(fun fmt () -> pp_print_string fmt " -> ")
+                  (fun fmt str -> pp_print_string fmt (String.escaped str))
+               ) ("^--" :: List.rev nestlvl)
+  in
+  let rec pp_val (nestlvl:string list) fmt = function
+    | Integer x -> Format.pp_print_string fmt @@ Int64.to_string x
+    | String x when String.length x <= 40 ->
+      Format.fprintf fmt "<string:%d:%S>" (String.length x) x
+    | String x ->
+      Format.fprintf fmt "<string:len %d>" (String.length x)
+    | List (( [ String _ | Integer _ ]
+            | [ String _ | Integer _ ; String _ | Integer _ ]
+            ) as lst) ->
+      Format.fprintf fmt "@[<v>[ @[<v>%a @]];@]"
+        Format.(pp_print_list @@ pp_val nestlvl) lst
+    | List lst ->
+      Format.fprintf fmt "@[<v>[  @[<v>%a@]@ ] ;@]"
+        Format.(pp_print_list ~pp_sep:Format.pp_print_cut @@ pp_val nestlvl) lst
+    | Dict lst ->
+      Format.fprintf fmt "@[<v>{  @[<v>%a@]@ } ;@]"
+        Format.(pp_print_list ~pp_sep:Format.pp_print_cut (fun fmt ->
+            (function
+              | key, ((String _ (* don't print newline before if: *)
+                      | List (_::_::[] | _::[] | [])
+                      | Integer _  ) as x) ->
+                Format.fprintf fmt "( %S, @[<v>%a@] );" key
+                  (pp_val []) x
+              | (key,x) ->
+                Format.fprintf fmt "@[<v>( \"@[<v>%a\":@ %a@]@ @]) ; %a"
+                  Format.(fun x -> pp_print_as x 2) (String.escaped key)
+                  (pp_val ((match x with | List _ -> "[]"
+                                         | _ -> "")::key::nestlvl)) x
+                  pp_nest (key::nestlvl)
+            )
+          )) lst
+  in
+  (pp_val []) fmt benc
+
 module Str_conv = struct
   open Printf
   let of_int i = sprintf "i%Lde" i

--- a/lib/bencode.mli
+++ b/lib/bencode.mli
@@ -28,6 +28,8 @@ val dict_of_list : (string*t) list -> t
 
 val pretty_print : t -> string
 
+(** [pp fmt tree] is the bencode [tree] pretty-printed in a human-readable
+    format on [fmt].*)
 val pp : Format.formatter -> t -> unit
 
 val decode : [< src] -> t

--- a/lib/bencode.mli
+++ b/lib/bencode.mli
@@ -28,6 +28,8 @@ val dict_of_list : (string*t) list -> t
 
 val pretty_print : t -> string
 
+val pp : Format.formatter -> t -> unit
+
 val decode : [< src] -> t
 
 (** [encode] is not tail recursive *)


### PR DESCRIPTION
I didn't touch `pretty_print` as I didn't want to break the API, and `pp` seems to be the conventional name for these printers.

The output generated looks like this:
```
{  ( "announce", <string:40:"udp://tracker.leechers-paradise.org:6969"> );
   ( "announce-list":
      [  <string:40:"udp://tracker.leechers-paradise.org:6969">
         <string:21:"udp://zer0day.ch:1337">
         <string:27:"udp://open.demonii.com:1337">
         <string:34:"udp://tracker.coppersurfer.tk:6969">
         <string:28:"udp://exodus.desync.com:6969">
      ] ;
   ) ;  (* ^-- -> announce-list *)
   ( "info":
      {  ( "private", 0 );
         ( "name", <string:3:"lib"> );
         ( "piece length", 2097152 );
         ( "files":
            [  {  ( "length", 11062 );
                  ( "path", [ <string:13:"omgtorrent.ml"> ]; );
                  ( "sha1", <string:20:"n\152\164\017\020nn\185\210\020\162SK\021\148c\170\2171}"> );
                  ( "attr", <string:0:""> );
               } ;
               {  ( "length", 2086090 );
                  ( "path", [ <string:4:".pad">
                              <string:7:"2086090"> ]; );
                  ( "attr", <string:1:"p"> );
               } ;
               {  ( "length", 11 );
                  ( "path", [ <string:16:"omgtorrent.mllib"> ]; );
                  ( "sha1", <string:20:"\189\212\237\229\169\224w@\144\224K\213_\213\020\t%\210%\179"> );
                  ( "attr", <string:0:""> );
               } ;
               {  ( "length", 2097141 );
                  ( "path", [ <string:4:".pad">
                              <string:7:"2097141"> ]; );
                  ( "attr", <string:1:"p"> );
               } ;
               {  ( "length", 9133 );
                  ( "path", [ <string:14:"omgtorrent.ml~"> ]; );
                  ( "sha1", <string:20:"\178\160\253p.}I\159\007p\134\000\206+\242\210bb\186F"> );
                  ( "attr", <string:0:""> );
               } ;
               {  ( "length", 2088019 );
                  ( "path", [ <string:4:".pad">
                              <string:7:"2088019"> ]; );
                  ( "attr", <string:1:"p"> );
               } ;
               {  ( "length", 1390 );
                  ( "path", [ <string:14:"omgtorrent.mli"> ]; );
                  ( "sha1", <string:20:"I\245\220\014\162^\255[\158\181M\253\\\2073\148cK\025q"> );
                  ( "attr", <string:0:""> );
               } ;
               {  ( "length", 2095762 );
                  ( "path", [ <string:4:".pad">
                              <string:7:"2095762"> ]; );
                  ( "attr", <string:1:"p"> );
               } ;
               {  ( "length", 0 );
                  ( "path":
                     [  <string:3:"foo">
                        <string:4:"bars">
                        <string:10:"empty.file">
                     ] ;
                  ) ;  (* ^-- -> info ->  -> files -> [] -> path *)
                  ( "sha1", <string:20:"\2189\163\238^kK\r2U\191\239\149`\024\144\175\216\007\t"> );
                  ( "attr", <string:0:""> );
               } ;
               {  ( "length", 2097152 );
                  ( "path", [ <string:4:".pad">
                              <string:7:"2097152"> ]; );
                  ( "attr", <string:1:"p"> );
               } ;
            ] ;
         ) ;  (* ^-- -> info ->  -> files *)
         ( "pieces", <string:len 100> );
      } ;
   ) ;  (* ^-- -> info *)
   ( "magnet-info":
      {  ( "display-name", <string:3:"lib"> );
         ( "info_hash", <string:20:"\t\161\234\234s\158\251\201\006uxv\248a\014\187\248[\186h"> );
      } ;
   ) ;  (* ^-- -> magnet-info *)
} ;
```